### PR TITLE
Add speed up to camera when frog gets too far from bird

### DIFF
--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -408,6 +408,8 @@ MonoBehaviour:
   initialMovement: {x: 0, y: 0.1, z: 0}
   increaseMovement: {x: 0, y: 0.1, z: 0}
   increaseInterval: 10
+  boostAmount: {x: 0, y: 5, z: 0}
+  boostDuration: 0.5
 --- !u!1 &157343227
 GameObject:
   m_ObjectHideFlags: 0
@@ -578,7 +580,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   target: {fileID: 974476604}
-  trackingDistance: 3
+  trackingDistance: 2.5
+  maxDistance: 8.5
   startPosition: {x: 0, y: -4.5, z: 10}
   entranceTime: 1
   flapInterval: 15

--- a/Assets/Scripts/Bird.cs
+++ b/Assets/Scripts/Bird.cs
@@ -6,6 +6,7 @@ public class Bird : MonoBehaviour {
 
     public GameObject target;
     public float trackingDistance;
+    public float maxDistance;
     public Vector3 startPosition;
     public float entranceTime;
     public float flapInterval;
@@ -36,7 +37,8 @@ public class Bird : MonoBehaviour {
 
         if (isChasing) {
             Vector3 pos = transform.position;
-            if (target.transform.position.y - pos.y < trackingDistance) {
+            float distance = target.transform.position.y - pos.y;
+            if (distance < trackingDistance) {
                 pos.x = target.transform.position.x;
                 animator.SetBool("Flapping", true);
             } else {
@@ -50,6 +52,10 @@ public class Bird : MonoBehaviour {
                 }
             }
             transform.position = Vector3.MoveTowards(transform.position, pos, 0.05f);
+
+            if (distance > maxDistance) {
+                CameraController.GetSingleton().StartBoostCameraSpeed();
+            }
         }
     }
 

--- a/Assets/Scripts/CameraController.cs
+++ b/Assets/Scripts/CameraController.cs
@@ -8,10 +8,14 @@ public class CameraController : MonoBehaviour {
     public Vector3 initialMovement;
     public Vector3 increaseMovement;
     public float increaseInterval;
+    public Vector3 boostAmount;
+    public float boostDuration;
 
     private bool isCameraMovementEnabled;
     private float timer;
     private Vector3 currentMovement;
+    private bool isBoost;
+    private float boostTimer;
 
     void Awake() {
         if (singleton != null) {
@@ -31,7 +35,18 @@ public class CameraController : MonoBehaviour {
         if (!isCameraMovementEnabled) {
             return;
         }
-        transform.position += (currentMovement * Time.deltaTime);
+
+        Vector3 moveAmount = currentMovement;
+        if (isBoost) {
+            moveAmount += boostAmount;
+            if (boostTimer > boostDuration) {
+                boostTimer = 0;
+                isBoost = false;
+            } else {
+                boostTimer += Time.deltaTime;
+            }
+        }
+        transform.position += (moveAmount * Time.deltaTime);
 
         if (timer > increaseInterval) {
             timer = 0;
@@ -59,5 +74,9 @@ public class CameraController : MonoBehaviour {
 
     public Vector3 GetCameraPosition() {
         return transform.position;
+    }
+
+    public void StartBoostCameraSpeed() {
+        isBoost = true;
     }
 }


### PR DESCRIPTION
The boost is currently set to move around 3 lilypads forward. Seems quite punishing in the late game. But then again, user can choose to go to the edge or not. So I think it should be OK.